### PR TITLE
Fix build errors and extern globals

### DIFF
--- a/pintos-kaist/Make.config
+++ b/pintos-kaist/Make.config
@@ -18,6 +18,7 @@ DEFINES =
 WARNINGS = -Wall -W -Wstrict-prototypes -Wmissing-prototypes -Wsystem-headers
 CFLAGS = -g -msoft-float -O0 -fno-omit-frame-pointer -mno-red-zone
 CFLAGS += -mcmodel=large -fno-plt -fno-pic -mno-sse
+CFLAGS += -fcommon
 CPPFLAGS = -nostdinc -I$(SRCDIR) -I$(SRCDIR)/include/lib -I$(SRCDIR)/include
 CPPFLAGS += -I$(SRCDIR)/include/lib/kernel
 ASFLAGS = -Wa,--gstabs -mcmodel=large

--- a/pintos-kaist/include/userprog/syscall.h
+++ b/pintos-kaist/include/userprog/syscall.h
@@ -4,6 +4,6 @@
 void syscall_init (void);
 void sys_exit(int);
 
-struct lock filesys_lock;	// 파일 시스템 동기화용 전역 락
+extern struct lock filesys_lock;	// 파일 시스템 동기화용 전역 락
 
 #endif /* userprog/syscall.h */

--- a/pintos-kaist/include/vm/anon.h
+++ b/pintos-kaist/include/vm/anon.h
@@ -8,8 +8,8 @@ struct anon_page {
     size_t swap_slot;
 };
 
-struct lock swap_lock;
-int *slot_refcnt;
+extern struct lock swap_lock;
+extern int *slot_refcnt;
 #define SECTORS_PER_PAGE 8
 #define INVALID_SWAP_SLOT SIZE_MAX
 

--- a/pintos-kaist/userprog/syscall.c
+++ b/pintos-kaist/userprog/syscall.c
@@ -16,6 +16,8 @@
 #include "filesys/filesys.h"        // 파일 시스템 전반에 대한 함수 및 초기화/포맷 인터페이스
 #include "filesys/file.h"           // 개별 파일 객체(file 구조체) 및 파일 입출력 함수 정의 (read, write 등)
 
+struct lock filesys_lock;
+
 void syscall_entry (void);
 void syscall_handler (struct intr_frame *);
 void check_address(void *addr);

--- a/pintos-kaist/vm/anon.c
+++ b/pintos-kaist/vm/anon.c
@@ -7,6 +7,8 @@
 #include "devices/disk.h"
 
 static struct bitmap *swap_table;
+struct lock swap_lock;
+int *slot_refcnt;
 
 /* DO NOT MODIFY BELOW LINE */
 static struct disk *swap_disk;


### PR DESCRIPTION
## Summary
- avoid global symbol collisions by declaring `swap_lock`, `slot_refcnt`, and `filesys_lock` as externs
- define these globals in their respective source files
- enable `-fcommon` so tests link with modern GCC

## Testing
- `make` (pass)
- `make check` *(fails: qemu-system-x86_64 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68402bb773ac83288199af88dbfde49d