### PR TITLE
Handle lazy load metadata in SPT copy

### DIFF
--- a/pintos-kaist/vm/uninit.c
+++ b/pintos-kaist/vm/uninit.c
@@ -10,6 +10,7 @@
 
 #include "vm/vm.h"
 #include "vm/uninit.h"
+#include "threads/malloc.h"
 
 static bool uninit_initialize (struct page *page, void *kva);
 static void uninit_destroy (struct page *page);
@@ -62,7 +63,16 @@ uninit_initialize (struct page *page, void *kva) {
  * PAGE will be freed by the caller. */
 static void
 uninit_destroy (struct page *page) {
-	struct uninit_page *uninit UNUSED = &page->uninit;
-	/* TODO: Fill this function.
-	 * TODO: If you don't have anything to do, just return. */
+        struct uninit_page *uninit = &page->uninit;
+
+        if (uninit->aux != NULL) {
+                if (VM_TYPE(uninit->type) == VM_FILE) {
+                        struct lazy_load_info *info = uninit->aux;
+                        free(info);
+                }
+                else {
+                        free(uninit->aux);
+                }
+                uninit->aux = NULL;
+        }
 }


### PR DESCRIPTION
## Summary
- duplicate lazy load metadata when copying supplemental page tables
- free uninit page aux data on destroy

## Testing
- `make -C vm` *(fails: qemu not found when running tests)*

------
https://chatgpt.com/codex/tasks/task_e_6840306520cc8328a844c0b8d307c2bd